### PR TITLE
Add ability to pass arbitrary kwargs to Clickhouse `do_connect`

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -49,6 +49,7 @@ class Backend(BaseSQLBackend):
         compression: (
             Literal["lz4", "lz4hc", "quicklz", "zstd"] | bool
         ) = _default_compression,
+        **kwargs: Any
     ):
         """Create a ClickHouse client for use with Ibis.
 
@@ -89,6 +90,7 @@ class Backend(BaseSQLBackend):
             password=password,
             client_name=client_name,
             compression=compression,
+            **kwargs
         )
 
     @property


### PR DESCRIPTION
From my experience using [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver), the user needs a decent bit of flexibility when configuring the client. For example, this is a common Client constructor from my company:

```python
import os

from clickhouse_driver import Client

client = Client(
    host=os.getenv("CH_HOST"),
    user=os.getenv("CH_USER"),
    password=os.getenv("CH_PASSWORD"),
    port=9440,
    secure=True,
    verify=False,
    database="default",
    compression=True,
    settings={"use_numpy": True},
)
```

Currently, I cannot get the Ibis Clickhouse connection to work because I can't pass in these kwargs.

References for setting clickhouse-driver settings:

- https://clickhouse-driver.readthedocs.io/en/latest/features.html#settings
- https://github.com/mymarilyn/clickhouse-driver/issues/196
- https://github.com/mymarilyn/clickhouse-driver/blob/4bbdef9a5a47a62843181f37554d1dc96e709e51/clickhouse_driver/client.py#L20